### PR TITLE
Fix cached images

### DIFF
--- a/include/dua_rviz_plugins/displays/visual_targets/visual_targets_display.hpp
+++ b/include/dua_rviz_plugins/displays/visual_targets/visual_targets_display.hpp
@@ -3,7 +3,7 @@
  *
  * dotX Automation <info@dotxautomation.com>
  *
- *  February 17, 2025
+ * February 17, 2025
  */
 
 /**
@@ -85,6 +85,7 @@ public:
    * @brief Constructor.
    */
   VisualTargetsDisplay();
+
   /**
    * @brief Destructor.
    */
@@ -95,6 +96,17 @@ protected:
    * @brief Initialize the display.
    */
   void onInitialize() override;
+
+  /**
+   * @brief Disable the display.
+   */
+  void onDisable() override;
+
+  /**
+   * @brief Reset the display.
+   */
+  void reset() override;
+
   /**
    * @brief Process the received message.
    */
@@ -113,21 +125,24 @@ private:
   void createInteractiveMarker(
     const geometry_msgs::msg::Pose & pose,
     const std::string & id);
+
   /**
    * @brief Process the interactive marker feedback.
    */
   void processFeedback(
     const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr & feedback,
     const std::string & id);
+
   /**
    * @brief Show the image in a dialog.
    */
   void showImage(const std::string & id);
 
+  rviz_common::properties::IntProperty * max_images_property_;
+
   std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
   std::unordered_map<std::string, Infos> map_;
   std::mutex mutex_;
-  rviz_common::properties::IntProperty * max_images_property_;
 };
 
 }  // namespace dua_rviz_plugins::displays::visual_targets

--- a/include/dua_rviz_plugins/displays/visual_targets/visual_targets_display.hpp
+++ b/include/dua_rviz_plugins/displays/visual_targets/visual_targets_display.hpp
@@ -41,8 +41,10 @@
 #include <rviz_common/ros_topic_display.hpp>
 #include <rviz_common/display_context.hpp>
 #include <rviz_common/frame_manager_iface.hpp>
+#include <rviz_common/properties/int_property.hpp>
 
 #include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 
@@ -64,10 +66,11 @@ namespace dua_rviz_plugins::displays::visual_targets
 {
 
 using geometry_msgs::msg::Pose;
+using sensor_msgs::msg::CompressedImage;
 using sensor_msgs::msg::Image;
 
-typedef std::tuple<std::string, Pose, Image> Info;
-typedef std::vector<Info> Infos;
+using Info = std::tuple<std::string, Pose, Image>;
+using Infos = std::deque<Info>;
 
 /**
  * @brief Display visual targets in RViz.
@@ -97,6 +100,12 @@ protected:
    */
   void processMessage(dua_mission_interfaces::msg::VisualTargets::ConstSharedPtr msg) override;
 
+private Q_SLOTS:
+  /**
+   * @brief Apply a new maximum number of cached images.
+   */
+  void updateMaxImages();
+
 private:
   /**
    * @brief Create an interactive marker.
@@ -115,10 +124,10 @@ private:
    */
   void showImage(const std::string & id);
 
-  std::string frame_id_;
   std::shared_ptr<interactive_markers::InteractiveMarkerServer> server_;
   std::unordered_map<std::string, Infos> map_;
   std::mutex mutex_;
+  rviz_common::properties::IntProperty * max_images_property_;
 };
 
 }  // namespace dua_rviz_plugins::displays::visual_targets

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dua_rviz_plugins</name>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
   <description>DUA custom RViz plugins.</description>
   <maintainer email="info@dotxautomation.com">dotX Automation s.r.l.</maintainer>
   <license>Apache-2.0</license>

--- a/src/displays/visual_targets/visual_targets_display.cpp
+++ b/src/displays/visual_targets/visual_targets_display.cpp
@@ -38,6 +38,7 @@ VisualTargetsDisplay::VisualTargetsDisplay()
     this,
     SLOT(updateMaxImages()));
   max_images_property_->setMin(1);
+  max_images_property_->setMax(50);
 }
 
 VisualTargetsDisplay::~VisualTargetsDisplay()

--- a/src/displays/visual_targets/visual_targets_display.cpp
+++ b/src/displays/visual_targets/visual_targets_display.cpp
@@ -60,6 +60,32 @@ void VisualTargetsDisplay::onInitialize()
     node);
 }
 
+void VisualTargetsDisplay::onDisable()
+{
+  RosTopicDisplay::onDisable();
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  map_.clear();
+  if (server_) {
+    server_->clear();
+    server_->applyChanges();
+  }
+}
+
+void VisualTargetsDisplay::reset()
+{
+  RosTopicDisplay::reset();
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  map_.clear();
+  if (server_) {
+    server_->clear();
+    server_->applyChanges();
+  }
+}
+
 void VisualTargetsDisplay::processMessage(
   dua_mission_interfaces::msg::VisualTargets::ConstSharedPtr msg)
 {

--- a/src/displays/visual_targets/visual_targets_display.cpp
+++ b/src/displays/visual_targets/visual_targets_display.cpp
@@ -28,8 +28,16 @@ namespace dua_rviz_plugins::displays::visual_targets
 {
 
 VisualTargetsDisplay::VisualTargetsDisplay()
-: rviz_common::RosTopicDisplay<dua_mission_interfaces::msg::VisualTargets>()
+: rviz_common::RosTopicDisplay<dua_mission_interfaces::msg::VisualTargets>(),
+  max_images_property_(nullptr)
 {
+  max_images_property_ = new rviz_common::properties::IntProperty(
+    "Max Images",
+    10,
+    "Maximum number of images stored per visual target.",
+    this,
+    SLOT(updateMaxImages()));
+  max_images_property_->setMin(1);
 }
 
 VisualTargetsDisplay::~VisualTargetsDisplay()
@@ -54,9 +62,13 @@ void VisualTargetsDisplay::onInitialize()
 void VisualTargetsDisplay::processMessage(
   dua_mission_interfaces::msg::VisualTargets::ConstSharedPtr msg)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
+
   // Clear the server
-  mutex_.lock();
   server_->clear();
+
+  const auto max_images =
+    static_cast<std::size_t>(std::max(1, max_images_property_->getInt()));
 
   // Get the agent name from frame_id
   std::string agent = msg->targets.header.frame_id;
@@ -68,7 +80,7 @@ void VisualTargetsDisplay::processMessage(
       cv::Mat frame;
       Image::SharedPtr img_msg = nullptr;
       std::string encoding(sensor_msgs::image_encodings::BGR8);
-      if (!(msg->image.format.empty())) {
+      if (!msg->image.format.empty()) {
         size_t pos = msg->image.format.find(";");
         if (pos != std::string::npos) {
           encoding = msg->image.format.substr(0, pos);
@@ -81,7 +93,6 @@ void VisualTargetsDisplay::processMessage(
       } catch (const std::exception & e) {
         RCLCPP_ERROR(rclcpp::get_logger("VisualTargetsDisplay"), "Error processing image: %s",
             e.what());
-        mutex_.unlock();
         return;
       }
 
@@ -89,21 +100,37 @@ void VisualTargetsDisplay::processMessage(
       std::string id = detection.results[0].hypothesis.class_id;
       std::replace(id.begin(), id.end(), ' ', '_');
       const Info info = {agent, detection.results[0].pose.pose, *img_msg};
-      map_[id].push_back(info);
+      map_[id].push_front(info);
+      while (map_[id].size() > max_images) {
+        map_[id].pop_back();
+      }
     }
   }
   // Create interactive markers for each visual target
   for (const auto & entry : map_) {
     const auto & id = entry.first;
-    const Info & infos = entry.second.back();
-    const Pose & pose = std::get<1>(infos);
+    const Info & info = entry.second.front();
+    const Pose & pose = std::get<1>(info);
     createInteractiveMarker(
       pose,
       id);
   }
   // Update the server
   server_->applyChanges();
-  mutex_.unlock();
+}
+
+void VisualTargetsDisplay::updateMaxImages()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  const auto max_images =
+    static_cast<std::size_t>(std::max(1, max_images_property_->getInt()));
+
+  for (auto & [id, infos] : map_) {
+    while (infos.size() > max_images) {
+      infos.pop_back();
+    }
+  }
 }
 
 void VisualTargetsDisplay::createInteractiveMarker(
@@ -212,13 +239,13 @@ void VisualTargetsDisplay::processFeedback(
 
 void VisualTargetsDisplay::showImage(const std::string & id)
 {
-  mutex_.lock();
+  std::lock_guard<std::mutex> lock(mutex_);
 
-  const Infos & infos = map_[id];
-  if (infos.empty()) {
-    mutex_.unlock();
+  const auto it = map_.find(id);
+  if (it == map_.end() || it->second.empty()) {
     return;
   }
+  const Infos & infos = it->second;
 
   // Create a dialog to display the images
   QDialog * dialog = new QDialog();
@@ -237,8 +264,7 @@ void VisualTargetsDisplay::showImage(const std::string & id)
   scroll_layout->setContentsMargins(0, 0, 0, 0);
 
   // Iterate from latest to oldest
-  for (auto it = infos.rbegin(); it != infos.rend(); ++it) {
-    const Info & info = *it;
+  for (const auto & info : infos) {
     const sensor_msgs::msg::Image & image = std::get<2>(info);
     QImage qimage;
     const auto & encoding = image.encoding;
@@ -312,8 +338,6 @@ void VisualTargetsDisplay::showImage(const std::string & id)
   dialog->setMinimumSize(640, 480);
   dialog->adjustSize();
   dialog->show();
-
-  mutex_.unlock();
 }
 
 }  // namespace dua_rviz_plugins::displays::visual_targets


### PR DESCRIPTION
This pull request introduces a configurable maximum number of cached images per visual target in the `VisualTargetsDisplay` RViz plugin, improves thread safety, and updates internal data structures for more efficient image management. 

Version update:
- Bumped the package version from 1.1.2 to 1.1.3 in package.xml.
